### PR TITLE
第一次添加提醒时会报错

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -94,6 +94,9 @@ export function apply(ctx: Context) {
             try {
                 await ctx.database.create('keywordRemind', {cid, uid, keyword, botId});
                 await session.bot.sendPrivateMessage(uid, `在 ${cName}(${cid})中，当有人发送了关键词"${keyword}"时，我会提醒你哦~`);
+                if (!keywordTemp[cid]) { // 检查是否存在
+                    keywordTemp[cid] = []; // 不存在则初始化为空数组
+                }
                 keywordTemp[cid].push(keyword);
             }
             catch(err) {
@@ -113,6 +116,9 @@ export function apply(ctx: Context) {
                 try {
                     await ctx.database.create('keywordRemind', {cid, uid, keyword, botId});
                     await session.bot.sendPrivateMessage(uid, `在 ${cName}(${cid})中，当有人发送了关键词"${keyword}"时，我会提醒你哦~`);
+                    if (!keywordTemp[cid]) { // 检查是否存在
+                        keywordTemp[cid] = []; // 不存在则初始化为空数组
+                    }
                     keywordTemp[cid].push(keyword);
                 }
                 catch(err) {
@@ -140,6 +146,9 @@ export function apply(ctx: Context) {
                 const cid = guild.id;
                 if ((await session.bot.getGuildMemberList(guild.id)).data.some(member => member.user.id === uid)) {
                     await ctx.database.upsert('keywordRemind', [{cid, uid, keyword, botId}]);
+                    if (!keywordTemp[cid]) { // 检查是否存在
+                        keywordTemp[cid] = []; // 不存在则初始化为空数组
+                    }
                     keywordTemp[cid].push(keyword);
                 }
             });


### PR DESCRIPTION
第一次用的时候会报错，报错如下：
```
TypeError: Cannot read properties of undefined (reading 'push')
at _Command.<anonymous> (C:\koishi-bot\koishi-app\node_modules\koishi-plugin-fei-keywordreminder\lib\index.js:77:34)
at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
at async Array.<anonymous> (C:\koishi-bot\koishi-app\node_modules@koishijs\core\lib\index.cjs:1083:14)
at async _Command.execute (C:\koishi-bot\koishi-app\node_modules@koishijs\core\lib\index.cjs:1097:22)
at async C:\koishi-bot\koishi-app\node_modules@koishijs\core\lib\index.cjs:2066:22
at async Proxy.withScope (C:\koishi-bot\koishi-app\node_modules@koishijs\core\lib\index.cjs:1975:22)
at async next (C:\koishi-bot\koishi-app\node_modules@koishijs\core\lib\index.cjs:829:16)
at async next (C:\koishi-bot\koishi-app\node_modules@koishijs\core\lib\index.cjs:829:16)
at async next (C:\koishi-bot\koishi-app\node_modules@koishijs\core\lib\index.cjs:829:16)
at async Processor._handleMessage (C:\koishi-bot\koishi-app\node_modules@koishijs\core\lib\index.cjs:840:22)
```

问了下gemini 2.5 pro，它是下边这么分析的，我按它说的改法改了之后确实没再报错了：

**代码分析:**

1.  **`keywordTemp` 对象:** 你在插件顶层定义了一个 `const keywordTemp = {};`。这个对象的作用是作为内存缓存，存储每个群聊 (`cid`) 对应的关键词列表（`Array<string>`），以避免每次收到消息都查询数据库。
2.  **`cidKeywordUpdate` 函数:** 这个函数在插件 `ready` 时执行一次，用于从数据库加载数据填充 `keywordTemp`。它会遍历机器人所在的所有群聊，对于每个群聊 `cid`，执行：
    ```javascript
    keywordTemp[cid] = (await ctx.database.get('keywordRemind', { cid })).map((data => data.keyword));
    ```
    *   **关键点:** 如果某个群聊 `cid` 在数据库中 *没有任何* 关键词提醒记录，`ctx.database.get('keywordRemind', { cid })` 会返回一个空数组 `[]`。执行 `.map()` 后，`keywordTemp[cid]` 会被赋值为 `[]` (一个空数组)。这本身没问题。
    *   **潜在问题:** 如果机器人 *新加入* 一个群聊，或者某个群聊在机器人启动时 *没有任何* 提醒词，那么 `cidKeywordUpdate` *可能不会* 为这个 `cid` 在 `keywordTemp` 中创建条目，或者创建的是空数组。
3.  **`提醒.群提醒` 命令:**
    *   当用户执行这个命令添加一个新的关键词提醒时，代码会先将提醒信息写入数据库：`await ctx.database.create('keywordRemind', {cid, uid, keyword, botId});`
    *   **紧接着**，代码会尝试更新内存缓存 `keywordTemp`：
        ```javascript
        keywordTemp[cid].push(keyword); // <--- 报错行（对应编译后 JS 的 77 行附近）
        ```
    *   **问题所在:** 如果这是 *第一次* 为某个群聊 `cid` 添加关键词提醒，并且这个 `cid` 在 `keywordTemp` 中还不存在对应的键（或者因为某种原因，比如 `cidKeywordUpdate` 没有覆盖到这个新群，或者在启动时尚无数据导致未创建），那么 `keywordTemp[cid]` 的值就是 `undefined`。在 `undefined` 上调用 `.push()` 就会触发你看到的 `TypeError`。

**解决方案:**

在尝试向 `keywordTemp[cid]` 推送新关键词之前，你需要确保 `keywordTemp[cid]` 确实是一个数组。如果它不存在（是 `undefined`），你需要先将其初始化为一个空数组。